### PR TITLE
Added `app` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,65 @@
-.PHONY: clean env
-BUILDDST=./build
-ENV=$(BUILDDST)/.env
-REQ_ENV=$(BUILDDST)/.constraints_env
+.PHONY: clean packager_env Packager/constraints.txt app app_env package
+# Base python interpreter
 BASE_PYTHON=python3
-PYTHON=$(ENV)/bin/python
-PIP=$(ENV)/bin/pip
-REQ_PIP=$(REQ_ENV)/bin/pip
+# Packager venv vars
+PACKAGER_BUILDDST=./Packager/build
+PACKAGER_ENV=$(PACKAGER_BUILDDST)/.packager_env
+PACKAGER_PYTHON=$(PACKAGER_ENV)/bin/python
+PACKAGER_REQUIREMENTS=Packager/packagerRequirements.txt
+PACKAGER_CONSTRAINTS=Packager/constraints.txt
+# Constraints venv vars
+PACKAGER_CONST_ENV=$(PACKAGER_BUILDDST)/.constraints_env
+PACKAGER_CONST_PYTHON=$(PACKAGER_CONST_ENV)/bin/python
+# App venv vars
+APP_ENV=.env
+APP_PYTHON=$(APP_ENV)/bin/python
+APP_REQUIREMENTS=requirements.txt
+APP_CONSTRAINTS=constraints.txt
+
 # Separate requirements and constraints files
 # This allows for easier management of dependencies
 # and ensures reproducible builds
 # requirements.txt should only list versions if absolutely necessary
 # constraints.txt is auto-generated and pins exact versions
-REQUIREMENTS=Packager/packagerRequirements.txt
-CONSTRAINTS=Packager/constraints.txt
+
+
+app: app_env
+	$(APP_PYTHON) JumperlessWokwiBridge.py
+
+app_env: $(APP_ENV)/bin/activate
+$(APP_ENV)/bin/activate: $(APP_REQUIREMENTS)
+	$(BASE_PYTHON) -m venv $(APP_ENV)
+	$(APP_PYTHON) -m pip install --upgrade pip
+	$(APP_PYTHON) -m pip install -r $(APP_REQUIREMENTS)
 
 # Target to create and set up the virtual environment
 # Dependencies: requirements.txt and constraints.txt
-env: $(ENV)/bin/activate
-$(ENV)/bin/activate: $(REQUIREMENTS) $(CONSTRAINTS)
-	$(BASE_PYTHON) -m venv $(ENV)
-	$(PIP) install --upgrade pip
-	$(PIP) install -r $(REQUIREMENTS) -c $(CONSTRAINTS)
+packager_env: $(PACKAGER_ENV)/bin/activate
+$(PACKAGER_ENV)/bin/activate: $(PACKAGER_REQUIREMENTS) $(PACKAGER_CONSTRAINTS)
+	$(BASE_PYTHON) -m venv $(PACKAGER_ENV)
+	$(PACKAGER_PYTHON) -m pip install --upgrade pip
+	$(PACKAGER_PYTHON) -m pip install -r $(PACKAGER_REQUIREMENTS) -c $(PACKAGER_CONSTRAINTS)
 
 # Target to create constraints file
 # Dependencies: requirements.txt
 # Run `make constraints.txt` to update the versions of packages
 # that will be used in the build environment
 # This is useful when adding new packages or updating existing ones
-$(CONSTRAINTS): $(REQUIREMENTS)
-	rm -rf $(REQ_ENV)
-	$(BASE_PYTHON) -m venv $(REQ_ENV)
-	$(REQ_PIP) install --upgrade pip
-	$(REQ_PIP) install --no-input -U -r $(REQUIREMENTS)
-	$(REQ_PIP) freeze > $(CONSTRAINTS)
-	rm -rf $(REQ_ENV)
+$(PACKAGER_CONSTRAINTS): $(PACKAGER_REQUIREMENTS)
+	rm -rf $(PACKAGER_CONST_ENV)
+	$(BASE_PYTHON) -m venv $(PACKAGER_CONST_ENV)
+	$(PACKAGER_CONST_PYTHON) -m pip install --upgrade pip
+	$(PACKAGER_CONST_PYTHON) -m pip install --no-input -U -r $(PACKAGER_REQUIREMENTS)
+	$(PACKAGER_CONST_PYTHON) -m pip freeze > $(PACKAGER_CONSTRAINTS)
+	rm -rf $(PACKAGER_CONST_ENV)
 
 # Target to build the application
 # Dependencies: env and constraints
-package: env
-	$(PYTHON) Packager/JumperlessAppPackager.py
+package: packager_env
+	$(PACKAGER_PYTHON) Packager/JumperlessAppPackager.py
 
 # Target to clean up build artifacts
 clean:
-	rm -rf build
+	rm -rf $(PACKAGER_BUILDDST)
+	rm -rf $(APP_ENV)
 	rm -rf builds

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Jumperless-App
 An app to talk to your Jumperless V5
 
-## Make
-GNU make can be used to manage the python virtual environment and build process.
-i.e. `make package` will run JumperlessAppPackager.py after building a virtual environment
-with all proper dependencies installed.
+## Make Targets
+
+List of useful `make` targets:
+- `make app`: Runs the Jumperless App `JumperlessWokwiBridge.py` from source.
+    All python dependencies are installed in a virtual environment.
+    Also the default target, same as running bare `make`.
+- `make package`: Builds the distributable packages, same as running `python3 Packager/JumperlessAppPackager.py`.
+    All python dependencies are instaled in a dedicated virtual environment.
 
 ## Packager pip Versions
+
 Specific package versions are stipulated in `Packager/constraints.txt`.
 This keeps `Packager/packagerRequirements.txt` a little cleaner and allows for easier updating of versions.
 To update package versions, just run `make Packager/constraints.txt`


### PR DESCRIPTION
Can now run the app from the root directory with `make app`.  Useful for development.  Will build a virtual environment for the app.

`make app` will build a virtual environment and run the app from source, in the project root directory.

`make package` will package up the app with JumperlessAppPackager.py